### PR TITLE
bump typescript-formatter to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "karma-jasmine": "^1.0.2",
     "karma-jasmine-given": "^0.1.1",
     "karma-nested-reporter": "^0.1.4",
-    "typescript": "^1.8.10",
-    "typescript-formatter": "^2.3.0"
+    "typescript": "^2.0.6",
+    "typescript-formatter": "^4.0.0"
   },
   "peerDependencies": {
-    "typescript-formatter": "^2.3.0"
+    "typescript-formatter": "^4.0.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Bump typescript-formatter to 4.0.0 which requires TypeScript >= 2.0.6.

Could you also please be so kind to push a new release to npmjs.com?